### PR TITLE
Reschedule Workers Remotely

### DIFF
--- a/app/src/main/java/com/forcetower/uefs/core/storage/repository/FirebaseMessageRepository.kt
+++ b/app/src/main/java/com/forcetower/uefs/core/storage/repository/FirebaseMessageRepository.kt
@@ -84,7 +84,7 @@ class FirebaseMessageRepository @Inject constructor(
     private fun rescheduleSync(data: Map<String, String>) {
         val current = preferences.getString("stg_sync_frequency", "60")?.toIntOrNull() ?: 60
         val period = data["period"]?.toIntOrNull() ?: current
-        val forced = data["forced"]?.toBooleanOrNull() ?: false
+        val forced = data["forced"]?.toBooleanOrNull() ?: true
 
         /**
          * Se a frequencia atual for maior que a recomendada e a sincronização não for forçada,

--- a/app/src/main/java/com/forcetower/uefs/core/storage/repository/FirebaseMessageRepository.kt
+++ b/app/src/main/java/com/forcetower/uefs/core/storage/repository/FirebaseMessageRepository.kt
@@ -86,7 +86,15 @@ class FirebaseMessageRepository @Inject constructor(
         val period = data["period"]?.toIntOrNull() ?: current
         val forced = data["forced"]?.toBooleanOrNull() ?: false
 
-        if (current >= period && !forced) {
+        /**
+         * Se a frequencia atual for maior que a recomendada e a sincronização não for forçada,
+         * nada precisa ser feito.
+         *
+         * Note que não é maior ou igual, este método se torna conveniente para que o remetente
+         * possa enviar uma mensagem somente com o identificador reschedule_sync e o aparelho irá
+         * fazer o reschedule mesmo que nenhum parâmetro seja passado.
+        **/
+        if (current > period && !forced) {
             Timber.d("No action needed")
         } else {
             val nextPeriod = max(period, current)

--- a/app/src/main/java/com/forcetower/uefs/core/work/sync/SyncLinkedWorker.kt
+++ b/app/src/main/java/com/forcetower/uefs/core/work/sync/SyncLinkedWorker.kt
@@ -91,7 +91,7 @@ class SyncLinkedWorker(
         }
 
         fun stopWorker() {
-            WorkManager.getInstance().cancelAllWorkByTag(TAG)
+            WorkManager.getInstance().cancelAllWorkByTag(TAG).result.get()
         }
     }
 }

--- a/app/src/main/java/com/forcetower/uefs/core/work/sync/SyncMainWorker.kt
+++ b/app/src/main/java/com/forcetower/uefs/core/work/sync/SyncMainWorker.kt
@@ -67,11 +67,11 @@ class SyncMainWorker(
         private const val NAME = "worker_sagres_sync"
 
         // Function that creates a Sagres Sync Worker
-        fun createWorker(ctx: Context, @IntRange(from = 15, to = 9000) period: Int) {
+        fun createWorker(ctx: Context, @IntRange(from = 15, to = 9000) period: Int, forcedReplace: Boolean = false) {
             val preferences = PreferenceManager.getDefaultSharedPreferences(ctx)
             // We need to observe the frequency to know if we need to replace the current worker with a new one
             val current = preferences.getInt(PreferenceConstants.SYNC_FREQUENCY, 60)
-            val replace = current != period
+            val replace = current != period || forcedReplace
 
             // The Sync Worker requires internet connection
             val constraints = Constraints.Builder()

--- a/app/src/main/java/com/forcetower/uefs/feature/shared/extensions/StringExtensions.kt
+++ b/app/src/main/java/com/forcetower/uefs/feature/shared/extensions/StringExtensions.kt
@@ -38,3 +38,12 @@ fun String.makeSemester(): String {
 }
 
 fun String?.toTitleCase(): String? = WordUtils.toTitleCase(this)
+
+fun String?.toBooleanOrNull(): Boolean? {
+    if (this == null) return null
+    return try {
+        java.lang.Boolean.parseBoolean(this)
+    } catch (t: Throwable) {
+        null
+    }
+}


### PR DESCRIPTION
Closes #12 
Este PR faz com que os sincronizadores possam ser reagendados de forma remota.

Adicionado o identificador de mensagem: reschedule_sync

Ele pode levar até 2 argumentos no payload:
1. period: o novo período de sincronização, um valor inteiro. (Opcional, valor padrão: período atual do usuário)
2. forced: se este reagendamento deve ser forçado mesmo que a sincronização atual já respeite o novo período, um valor booleano. (Opcional, valor padrão: true)