### PR TITLE
fix(materials): stop cached material files colliding and escaping

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -35,8 +35,9 @@
             </intent-filter>
         </activity>
 
-        <!-- Grants PDF viewers read access to the offline document slots
-             under filesDir/documents (Comprovante / Histórico). -->
+        <!-- Grants external viewers read access to the offline document slots
+             under filesDir/documents (Comprovante / Histórico) and to the
+             downloaded material attachments under cacheDir/materials. -->
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/materials/MaterialsDetailViewModel.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/materials/MaterialsDetailViewModel.kt
@@ -162,8 +162,8 @@ internal class MaterialsDetailViewModel @Inject constructor(
             when (val outcome = openMaterial(material.id)) {
                 is Outcome.Ok -> {
                     val file = withContext(Dispatchers.IO) {
-                        File(context.cacheDir, "materials").apply { mkdirs() }
-                            .resolve(outcome.value.fileName.ifBlank { "material.pdf" })
+                        materialCacheFile(material.id, outcome.value.fileName)
+                            .apply { parentFile?.mkdirs() }
                             .apply { writeBytes(outcome.value.bytes) }
                     }
                     setState {
@@ -185,6 +185,22 @@ internal class MaterialsDetailViewModel @Inject constructor(
             }
         }
     }
+
+    // The name is uploader-supplied and not a trusted path. Every scan is named
+    // "digitalizacao.pdf", so the id keys the directory to stop distinct
+    // materials overwriting each other.
+    private fun materialCacheFile(materialId: String, fileName: String): File {
+        val root = File(context.cacheDir, "materials")
+        val target = File(root, "${basename(materialId)}/${basename(fileName)}")
+        if (!target.canonicalPath.startsWith(root.canonicalPath + File.separator)) {
+            return File(root, "untrusted/material.pdf")
+        }
+        return target
+    }
+
+    private fun basename(value: String) = File(value).name
+        .takeUnless { it.isBlank() || it == "." || it == ".." }
+        ?: "material.pdf"
 
     private fun confirmReport() {
         val material = currentState.material ?: return

--- a/apps/android/app/src/main/res/xml/file_provider_paths.xml
+++ b/apps/android/app/src/main/res/xml/file_provider_paths.xml
@@ -4,4 +4,8 @@
     <files-path
         name="documents"
         path="documents/" />
+    <!-- Downloaded material attachments, handed to the system viewer. -->
+    <cache-path
+        name="materials"
+        path="materials/" />
 </paths>

--- a/apps/ios/UNESKit/Sources/UNESKit/Data/Repositories/DocumentsRepository+Live.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Data/Repositories/DocumentsRepository+Live.swift
@@ -67,7 +67,7 @@ private func downloadPDF(from url: URL, filename: String) async throws -> URL {
     guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
         throw APIError.invalidResponse
     }
-    let destination = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+    let destination = FileManager.default.temporaryDirectory.appendingPathComponent(safeFileName(filename))
     try data.write(to: destination, options: .atomic)
     return destination
 }

--- a/apps/ios/UNESKit/Sources/UNESKit/Data/Repositories/MaterialsRepository+Live.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Data/Repositories/MaterialsRepository+Live.swift
@@ -97,7 +97,7 @@ extension MaterialsRepository: DependencyKey {
                     query: [URLQueryItem(name: "id", value: material.id)],
                     body: EmptyBody()
                 )
-                let url = try await downloadFile(from: dto.url, filename: dto.filename)
+                let url = try await downloadFile(from: dto.url, materialId: material.id, filename: dto.filename)
                 log.info("open ok id=\(material.id)")
                 return url
             } catch {
@@ -164,12 +164,19 @@ extension MaterialsRepository: DependencyKey {
 
 /// The presigned URL is its own bearer token — plain requests, no session
 /// header (same recipe as `DocumentsRepository`).
-private func downloadFile(from url: URL, filename: String) async throws -> URL {
+///
+/// Every scan uploads as "digitalizacao.pdf", so the id keys the directory to
+/// stop distinct materials overwriting each other.
+private func downloadFile(from url: URL, materialId: String, filename: String) async throws -> URL {
     let (data, response) = try await URLSession.shared.data(from: url)
     guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
         throw APIError.invalidResponse
     }
-    let destination = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("materials", isDirectory: true)
+        .appendingPathComponent(safeFileName(materialId), isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let destination = directory.appendingPathComponent(safeFileName(filename))
     try data.write(to: destination, options: .atomic)
     return destination
 }

--- a/apps/ios/UNESKit/Sources/UNESKit/Data/Repositories/SafeFileName.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Data/Repositories/SafeFileName.swift
@@ -1,0 +1,8 @@
+/// File names round-trip from whoever uploaded the file, so they are untrusted
+/// input rather than a path: a directory component would let a download escape
+/// the directory it is meant to land in.
+func safeFileName(_ value: String, fallback: String = "arquivo") -> String {
+    let name = value.split(separator: "/").last.map(String.init) ?? ""
+    guard !name.isEmpty, name != ".", name != ".." else { return fallback }
+    return name
+}


### PR DESCRIPTION
Follows a Crashlytics report:

```
Fatal Exception: java.lang.IllegalArgumentException: Failed to find configured root that contains
/data/data/com.forcetower.uefs/cache/materials/digitalizacao.pdf
    at androidx.core.content.FileProvider$SimplePathStrategy.getUriForFile(FileProvider.java:911)
    at ...MaterialsDetailScreenKt.viewFile(MaterialsDetailScreen.kt:1163)
```

## What was wrong

Three distinct problems, one of which was masking the others.

**1. FileProvider had no root for the material cache (the crash).**
`file_provider_paths.xml` only declared `<files-path name="documents" path="documents/"/>`, added for the Comprovante/Histórico PDFs. But `MaterialsDetailViewModel.openFile()` writes downloads to `cacheDir/materials`, which no root covered — so `getUriForFile` threw for *every* material open, not just this PDF.

**2. Distinct materials shared one cache path.**
The cache path was the uploader-supplied file name, and the scanner flow hardcodes `fileName = "digitalizacao.pdf"` (mirrored on iOS). The backend stores that name raw and returns it verbatim, so every scanned material in the app resolved to the same file. Blobs are content-addressed server-side, so only the client cache collided.

The bytes are correct at open time (the write immediately precedes the viewer launch), so the symptom is delayed: the external viewer holds a `content://` URI and many PDF viewers re-read on resume. Open A → background → open B → return to A now shows B.

**3. The name was used as a path, unsanitised.**
`resolve(fileName)` on a server-supplied string meant an upload named `../../databases/x` escaped the cache directory — and `writeBytes` lands *before* `getUriForFile` throws, so the write happened regardless. The FileProvider exception was the only thing incidentally bounding this.

## What changed

- Android: declare the `cache-path materials/` root the downloader actually writes to.
- Both clients: key the cache directory by material id, so the name still shows in the viewer but the path is unique.
- Both clients: reduce the name to a bare basename; Android additionally gates on a canonical-path containment check.
- iOS: the same sanitisation on the documents download, which had the same unsanitised write (no collision risk there — the two document kinds have fixed distinct names).

Paired with ForceTower/unes-backrooms#3 which rejects path-ish names at the upload boundary. These are independent: each holds on its own.

## Verification

- `:apps:android:app:compileDebugKotlin` passes locally.
- iOS was **not** built locally (written on Windows) — relying on `Build app (UNES)` / `Test UNESKit` in CI for the Swift.
- Rebased onto current main; both re-verified after the rebase.
- Not yet exercised on-device; the open-A/open-B/return-to-A sequence is the one to drive by hand.

## Note

`cacheDir/materials` is never pruned. Collisions were capping its growth by accident; per-material directories remove that cap, so downloads now accumulate until Android evicts the cache dir under pressure. Tolerable, but a prune on detail-screen exit would be tidier — left out of scope here.
