### PR TITLE
chore(materials): bound the download cache to 50 MB

### DIFF
--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/materials/MaterialsDetailViewModel.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/materials/MaterialsDetailViewModel.kt
@@ -165,6 +165,7 @@ internal class MaterialsDetailViewModel @Inject constructor(
                         materialCacheFile(material.id, outcome.value.fileName)
                             .apply { parentFile?.mkdirs() }
                             .apply { writeBytes(outcome.value.bytes) }
+                            .also { pruneMaterialCache(keeping = it) }
                     }
                     setState {
                         copy(
@@ -202,6 +203,26 @@ internal class MaterialsDetailViewModel @Inject constructor(
         .takeUnless { it.isBlank() || it == "." || it == ".." }
         ?: "material.pdf"
 
+    // Downloads accumulate here until the OS evicts the cache dir. Once past the
+    // budget, drop the oldest entries — never the one just written, which an
+    // external viewer is about to read.
+    private fun pruneMaterialCache(keeping: File) {
+        val root = File(context.cacheDir, "materials")
+        val entries = root.listFiles().orEmpty()
+        var total = entries.sumOf { it.cachedSize() }
+        if (total <= MATERIAL_CACHE_BUDGET_BYTES) return
+
+        val keptDir = keeping.parentFile?.canonicalFile
+        entries
+            .filter { it.canonicalFile != keptDir }
+            .sortedBy { it.lastModified() }
+            .forEach { entry ->
+                if (total <= MATERIAL_CACHE_BUDGET_BYTES) return
+                total -= entry.cachedSize()
+                entry.deleteRecursively()
+            }
+    }
+
     private fun confirmReport() {
         val material = currentState.material ?: return
         val reason = currentState.reportReason ?: return
@@ -224,3 +245,8 @@ internal class MaterialsDetailViewModel @Inject constructor(
         }
     }
 }
+
+private const val MATERIAL_CACHE_BUDGET_BYTES = 50L * 1024 * 1024
+
+private fun File.cachedSize(): Long =
+    if (isFile) length() else walkBottomUp().filter { it.isFile }.sumOf { it.length() }

--- a/apps/ios/UNESKit/Sources/UNESKit/Data/Repositories/MaterialsRepository+Live.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Data/Repositories/MaterialsRepository+Live.swift
@@ -172,13 +172,55 @@ private func downloadFile(from url: URL, materialId: String, filename: String) a
     guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
         throw APIError.invalidResponse
     }
-    let directory = FileManager.default.temporaryDirectory
-        .appendingPathComponent("materials", isDirectory: true)
-        .appendingPathComponent(safeFileName(materialId), isDirectory: true)
+    let directory = materialsCacheRoot().appendingPathComponent(safeFileName(materialId), isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     let destination = directory.appendingPathComponent(safeFileName(filename))
     try data.write(to: destination, options: .atomic)
+    pruneMaterialsCache(keeping: directory)
     return destination
+}
+
+private func materialsCacheRoot() -> URL {
+    FileManager.default.temporaryDirectory.appendingPathComponent("materials", isDirectory: true)
+}
+
+private let materialsCacheBudget = 50 * 1024 * 1024
+
+/// Downloads pile up in the temp directory until the system purges it. Once the
+/// materials cache passes the budget, drop the oldest entries — never `kept`,
+/// which the viewer is about to read.
+private func pruneMaterialsCache(keeping kept: URL) {
+    let fm = FileManager.default
+    guard let entries = try? fm.contentsOfDirectory(
+        at: materialsCacheRoot(),
+        includingPropertiesForKeys: [.contentModificationDateKey, .totalFileAllocatedSizeKey]
+    ) else { return }
+
+    let items = entries.map { (url: $0, size: directorySize($0), modified: modificationDate($0)) }
+    var total = items.reduce(0) { $0 + $1.size }
+    guard total > materialsCacheBudget else { return }
+
+    let keptPath = kept.standardizedFileURL.path
+    for item in items.sorted(by: { $0.modified < $1.modified }) {
+        if total <= materialsCacheBudget { break }
+        if item.url.standardizedFileURL.path == keptPath { continue }
+        total -= item.size
+        try? fm.removeItem(at: item.url)
+    }
+}
+
+private func directorySize(_ url: URL) -> Int {
+    let fm = FileManager.default
+    guard let files = fm.enumerator(at: url, includingPropertiesForKeys: [.totalFileAllocatedSizeKey]) else { return 0 }
+    var bytes = 0
+    for case let file as URL in files {
+        bytes += (try? file.resourceValues(forKeys: [.totalFileAllocatedSizeKey]).totalFileAllocatedSize) ?? 0
+    }
+    return bytes
+}
+
+private func modificationDate(_ url: URL) -> Date {
+    (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
 }
 
 private func uploadFile(_ data: Data, to url: URL, fileKind: MaterialFileKind) async throws {


### PR DESCRIPTION
Follow-up to #101. That PR gave each material its own cache directory, which removed the accidental growth cap the old filename collisions imposed (every scan reused `digitalizacao.pdf`, so the cache never grew past one file). Downloads now accumulate until the OS evicts the cache directory.

## What changed

Prune the materials download cache on each open, on both clients:

- Compute the total size of the `materials` cache; if it's within 50 MB, do nothing.
- Otherwise drop entries oldest-first until back under 50 MB.
- **Never** delete the entry just written — an external viewer (Android `ACTION_VIEW`, iOS QuickLook) is about to read it. Deleting it would reintroduce a variant of the collision bug #101 fixed.

Android additionally sweeps up any flat files left by the pre-#101 layout, since they count toward the total the same way.

Runs in the existing IO/download path, so no new threading. Work is bounded and only happens once the cache is actually over budget.

## Verification

- `:apps:android:app:compileDebugKotlin` passes locally.
- iOS was **not** built locally (Windows) — relying on `Build app (UNES)` / `Test UNESKit` in CI.
- Not exercised on-device. The behaviour to spot-check: open enough large materials to exceed 50 MB, then confirm older cached files are gone while the currently-open one still renders.
