### PR TITLE
fix(score): compute the CR per program instead of blending degrees

### DIFF
--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/disciplines/DisciplinesListViewModel.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/disciplines/DisciplinesListViewModel.kt
@@ -5,6 +5,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.forcetower.melon.core.analytics.Analytics
 import dev.forcetower.melon.core.analytics.ContentTypes
 import dev.forcetower.melon.core.common.Outcome
+import dev.forcetower.melon.feature.disciplines.domain.model.OverallScore
+import dev.forcetower.melon.feature.disciplines.domain.model.ProgramScore
 import dev.forcetower.melon.feature.disciplines.domain.usecase.CalculateOverallScoreUseCase
 import dev.forcetower.melon.feature.disciplines.domain.usecase.ObserveDisciplinesListUseCase
 import dev.forcetower.melon.feature.sync.domain.usecase.SyncSemesterUseCase
@@ -30,9 +32,13 @@ internal data class DisciplinesUiState(
     val current: Semester? = null,
     val past: List<Semester> = emptyList(),
     val pending: List<Semester> = emptyList(),
-    // Lifetime CR (hours-weighted mean of final grades) — feeds the
-    // "Desempenho acumulado" card on the Histórico tab.
-    val overallScore: Double? = null,
+    // Lifetime CR (hours-weighted mean of final grades) per program — feeds
+    // the "Desempenho acumulado" card on the Histórico tab. Students who only
+    // ever took graduação disciplines have a single entry.
+    val score: OverallScore = OverallScore.Empty,
+    // The program the user tapped, or null to follow whichever one they are
+    // currently in. Wrapped because `null` is itself a track (the graduação).
+    val selectedTrack: TrackSelection? = null,
     val downloading: Set<String> = emptySet(),
     val downloadError: String? = null,
     // Seed handover for the detail route. Set when the list-card is tapped so
@@ -42,12 +48,31 @@ internal data class DisciplinesUiState(
     // with the tapped Discipline as the seed.
     val openOfferId: String? = null,
     val openSeed: Discipline? = null,
-) : UiState
+) : UiState {
+    // Track the Histórico tab is showing: the tapped one, else the program
+    // the student is currently in, else the newest program on record. The
+    // selection is checked for presence, not for a non-null track — picking
+    // "Graduação" means picking `null`.
+    val shownTrack: String?
+        get() = when (val selection = selectedTrack) {
+            null -> score.currentTrack ?: past.firstOrNull()?.track
+            else -> selection.track
+        }
+
+    val shownProgram: ProgramScore?
+        get() = score.programs.firstOrNull { it.track == shownTrack }
+}
+
+// A chosen track. `null` inside means the graduação, which is why the choice
+// itself has to be nullable one level up.
+@JvmInline
+internal value class TrackSelection(val track: String?)
 
 internal sealed interface DisciplinesIntent : UiIntent {
     data class Download(val semesterCode: String) : DisciplinesIntent
     data class OpenDiscipline(val discipline: Discipline) : DisciplinesIntent
     data object CloseDiscipline : DisciplinesIntent
+    data class SelectProgram(val track: String?) : DisciplinesIntent
 }
 
 internal sealed interface DisciplinesEffect : UiEffect
@@ -65,7 +90,7 @@ internal class DisciplinesListViewModel @Inject constructor(
             observeList().collect { value -> apply(value) }
         }
         viewModelScope.launch {
-            calculateOverallScore().collect { value -> setState { copy(overallScore = value) } }
+            calculateOverallScore().collect { value -> setState { copy(score = value) } }
         }
     }
 
@@ -80,6 +105,9 @@ internal class DisciplinesListViewModel @Inject constructor(
             }
             DisciplinesIntent.CloseDiscipline -> setState {
                 copy(openOfferId = null, openSeed = null)
+            }
+            is DisciplinesIntent.SelectProgram -> setState {
+                copy(selectedTrack = TrackSelection(intent.track))
             }
         }
     }
@@ -128,6 +156,7 @@ private fun mapSemester(raw: KmpSemester): Semester = Semester(
     isDownloaded = true,
     estimatedCount = null,
     dbSemesterId = raw.semesterId,
+    track = raw.track,
 )
 
 private fun mapPending(raw: KmpPending): Semester = Semester(
@@ -136,6 +165,7 @@ private fun mapPending(raw: KmpPending): Semester = Semester(
     isDownloaded = false,
     estimatedCount = null,
     dbSemesterId = raw.semesterId,
+    track = raw.track,
 )
 
 // Per-evaluation detail from upstream lands in a single "Geral" section here —

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/disciplines/DisciplinesModels.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/disciplines/DisciplinesModels.kt
@@ -123,6 +123,8 @@ internal data class Semester(
     val estimatedCount: Int? = null,
     // Opaque DB primary key used by SyncSemesterUseCase.
     val dbSemesterId: String? = null,
+    // Program calendar this semester belongs to; null is the graduação.
+    val track: String? = null,
 )
 
 internal enum class AbsenceRisk { Ok, Warn, Risk }

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/disciplines/DisciplinesScreen.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/disciplines/DisciplinesScreen.kt
@@ -96,6 +96,7 @@ internal fun DisciplinesScreen(
     // card stack. The promoted semester keeps its place on the Histórico tab,
     // which always lists every downloaded past semester.
     val effectiveCurrent = current ?: past.firstOrNull()
+    val programTracks = remember(state.past, state.pending) { programTracks(state) }
 
     DisciplinesContent(
         current = effectiveCurrent,
@@ -103,12 +104,23 @@ internal fun DisciplinesScreen(
         past = past,
         pending = state.pending,
         downloading = state.downloading,
-        overallScore = state.overallScore,
+        programTracks = programTracks,
+        selectedTrack = state.shownTrack,
+        overallScore = state.shownProgram?.value,
+        onSelectProgram = { vm.onIntent(DisciplinesIntent.SelectProgram(it)) },
         onOpenDiscipline = onOpenDiscipline,
         onDownload = { vm.onIntent(DisciplinesIntent.Download(it)) },
         bottomInset = bottomInset,
         modifier = modifier,
     )
+}
+
+// The programs present in the history, newest first. Empty for the students
+// who only ever took graduação disciplines — the Histórico keeps its
+// single-program layout instead of offering a choice of one.
+private fun programTracks(state: DisciplinesUiState): List<String?> {
+    val tracks = (state.past + state.pending).map { it.track }.distinct()
+    return if (tracks.size <= 1) emptyList() else tracks
 }
 
 private const val PAGE_CURRENT = 0
@@ -122,7 +134,10 @@ private fun DisciplinesContent(
     past: List<Semester>,
     pending: List<Semester>,
     downloading: Set<String>,
+    programTracks: List<String?>,
+    selectedTrack: String?,
     overallScore: Double?,
+    onSelectProgram: (String?) -> Unit,
     onOpenDiscipline: (Discipline) -> Unit,
     onDownload: (String) -> Unit,
     bottomInset: Dp,
@@ -178,7 +193,10 @@ private fun DisciplinesContent(
                     past = past,
                     pending = pending,
                     downloading = downloading,
+                    programTracks = programTracks,
+                    selectedTrack = selectedTrack,
                     overallScore = overallScore,
+                    onSelectProgram = onSelectProgram,
                     onOpenDiscipline = onOpenDiscipline,
                     onDownload = onDownload,
                     bottomInset = bottomInset,
@@ -388,15 +406,28 @@ private fun HistoryPane(
     past: List<Semester>,
     pending: List<Semester>,
     downloading: Set<String>,
+    programTracks: List<String?>,
+    selectedTrack: String?,
     overallScore: Double?,
+    onSelectProgram: (String?) -> Unit,
     onOpenDiscipline: (Discipline) -> Unit,
     onDownload: (String) -> Unit,
     bottomInset: Dp,
 ) {
+    // A student enrolled in more than one program (a mestrado after the
+    // graduação, say) reads one program at a time: mixing their semesters
+    // into a single list is what made the accumulated CR meaningless.
+    val visiblePast = remember(past, programTracks, selectedTrack) {
+        if (programTracks.isEmpty()) past else past.filter { it.track == selectedTrack }
+    }
+    val visiblePending = remember(pending, programTracks, selectedTrack) {
+        if (programTracks.isEmpty()) pending else pending.filter { it.track == selectedTrack }
+    }
+
     // Single-open accordion — the most recent semester starts expanded,
     // matching the dc prototype's `openSem` behavior.
-    var openSemester by rememberSaveable(past.firstOrNull()?.id) {
-        mutableStateOf(past.firstOrNull()?.id)
+    var openSemester by rememberSaveable(visiblePast.firstOrNull()?.id) {
+        mutableStateOf(visiblePast.firstOrNull()?.id)
     }
 
     LazyColumn(
@@ -404,14 +435,14 @@ private fun HistoryPane(
         contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = bottomInset + 24.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        if (past.isEmpty() && pending.isEmpty()) {
+        if (visiblePast.isEmpty() && visiblePending.isEmpty()) {
             item("history-empty") { EmptyPaneMessage(text = stringResource(R.string.disciplines_history_empty)) }
             return@LazyColumn
         }
 
-        if (past.isNotEmpty()) {
+        if (visiblePast.isNotEmpty()) {
             item("history-summary") {
-                val all = past.flatMap { it.disciplines }
+                val all = visiblePast.flatMap { it.disciplines }
                 val decided = all.count { it.approved != null }
                 val approvalPercent = if (decided > 0) {
                     (all.count { it.approved == true } * 100.0 / decided).roundToInt()
@@ -422,6 +453,9 @@ private fun HistoryPane(
                     overallMean = overallScore,
                     taken = all.size,
                     approvalPercent = approvalPercent,
+                    programTracks = programTracks,
+                    selectedTrack = selectedTrack,
+                    onSelectProgram = onSelectProgram,
                     modifier = Modifier
                         .fadeUpOnAppear(delayMs = 120)
                         .padding(bottom = 6.dp),
@@ -429,7 +463,7 @@ private fun HistoryPane(
             }
         }
         itemsIndexed(
-            items = past,
+            items = visiblePast,
             key = { _, sem -> "past-${sem.id}" },
         ) { index, semester ->
             HistorySemesterCard(
@@ -446,7 +480,7 @@ private fun HistoryPane(
         // re-emits with the semester moved into `past`, so the placeholder
         // disappears once the fetch lands.
         itemsIndexed(
-            items = pending,
+            items = visiblePending,
             key = { _, sem -> "pending-${sem.id}" },
         ) { index, semester ->
             UndownloadedSemesterCard(
@@ -487,7 +521,10 @@ private fun DisciplinesContentPreview() {
             past = DisciplinesFixtures.PAST.map { it.tinted(palette) },
             pending = DisciplinesFixtures.PENDING,
             downloading = emptySet(),
+            programTracks = emptyList(),
+            selectedTrack = null,
             overallScore = DisciplinesFixtures.OVERALL_SCORE,
+            onSelectProgram = {},
             onOpenDiscipline = {},
             onDownload = {},
             bottomInset = 0.dp,

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/disciplines/components/HistorySummaryCard.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/disciplines/components/HistorySummaryCard.kt
@@ -2,6 +2,7 @@ package dev.forcetower.unes.ui.feature.disciplines.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,7 +10,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,12 +34,18 @@ import java.util.Locale
 
 // "Desempenho acumulado" card at the top of the Histórico tab — overall CR,
 // count of disciplines taken, and approval rate across downloaded semesters.
+// Every number belongs to one program: a student with a mestrado on top of
+// their graduação picks which one through the chip row, and students with a
+// single program never see it.
 @Composable
 internal fun HistorySummaryCard(
     overallMean: Double?,
     taken: Int,
     approvalPercent: Int?,
     modifier: Modifier = Modifier,
+    programTracks: List<String?> = emptyList(),
+    selectedTrack: String? = null,
+    onSelectProgram: (String?) -> Unit = {},
 ) {
     val shape = RoundedCornerShape(22.dp)
     Column(
@@ -51,6 +61,14 @@ internal fun HistorySummaryCard(
             style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp),
             color = MaterialTheme.colorScheme.outlineVariant,
         )
+        if (programTracks.isNotEmpty()) {
+            Spacer(Modifier.height(12.dp))
+            ProgramChips(
+                tracks = programTracks,
+                selectedTrack = selectedTrack,
+                onSelectProgram = onSelectProgram,
+            )
+        }
         Spacer(Modifier.height(14.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
             StatTile(
@@ -70,6 +88,51 @@ internal fun HistorySummaryCard(
                 label = stringResource(R.string.disciplines_history_approval_rate),
                 valueColor = MaterialTheme.melon.status.ok,
                 modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+// One chip per program the student has semesters in. The track code is the
+// label — upstream gives us no name for a program, only the suffix it stamps
+// on its semester codes (22.1RUE → "RUE").
+@Composable
+private fun ProgramChips(
+    tracks: List<String?>,
+    selectedTrack: String?,
+    onSelectProgram: (String?) -> Unit,
+) {
+    Row(
+        modifier = Modifier.horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        tracks.forEach { track ->
+            val selected = track == selectedTrack
+            FilterChip(
+                selected = selected,
+                onClick = { onSelectProgram(track) },
+                modifier = Modifier.height(32.dp),
+                shape = RoundedCornerShape(9.dp),
+                label = {
+                    Text(
+                        text = track ?: stringResource(R.string.disciplines_history_program_undergrad),
+                        style = MaterialTheme.typography.labelLarge.copy(
+                            fontWeight = if (selected) FontWeight.Bold else FontWeight.SemiBold,
+                        ),
+                    )
+                },
+                colors = FilterChipDefaults.filterChipColors(
+                    containerColor = Color.Transparent,
+                    labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    selectedContainerColor = MaterialTheme.colorScheme.primary,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                ),
+                border = FilterChipDefaults.filterChipBorder(
+                    enabled = true,
+                    selected = selected,
+                    borderColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.18f),
+                ),
             )
         }
     }
@@ -114,6 +177,12 @@ private fun StatTile(
 @Composable
 private fun HistorySummaryCardPreview() {
     MelonTheme {
-        HistorySummaryCard(overallMean = 7.0, taken = 16, approvalPercent = 88)
+        HistorySummaryCard(
+            overallMean = 7.0,
+            taken = 16,
+            approvalPercent = 88,
+            programTracks = listOf(null, "RUE"),
+            selectedTrack = null,
+        )
     }
 }

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/disciplines/components/HistorySummaryCard.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/disciplines/components/HistorySummaryCard.kt
@@ -116,7 +116,7 @@ private fun ProgramChips(
                 shape = RoundedCornerShape(9.dp),
                 label = {
                     Text(
-                        text = track ?: stringResource(R.string.disciplines_history_program_undergrad),
+                        text = track ?: stringResource(R.string.program_undergrad),
                         style = MaterialTheme.typography.labelLarge.copy(
                             fontWeight = if (selected) FontWeight.Bold else FontWeight.SemiBold,
                         ),

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/MeFixtures.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/MeFixtures.kt
@@ -40,6 +40,8 @@ internal object MeFixtures {
         progressPct = 100,
         cr = 6.7,
         crDelta = 0.1,
+        crTrack = null,
+        crIsSplit = false,
         attendancePercent = 94,
         semesterOrdinal = 6,
         semesterStart = "18 fev",

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/MeModels.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/MeModels.kt
@@ -28,11 +28,17 @@ internal data class ProfileIdentity(
     val semesterWeek: Int,
     val semesterTotalWeeks: Int,
     val progressPct: Int,
-    // Lifetime CR ("Score"). Null until the score flow emits — rendered "–".
+    // Lifetime CR ("Score") of one program. Null until the score flow emits
+    // — rendered "–".
     val cr: Double?,
     // Signed movement caused by the last closed semester; the delta row
     // renders only when |delta| ≥ 0.1 (same rule as iOS).
     val crDelta: Double?,
+    // Program the CR belongs to; null is the graduação. Only meaningful when
+    // `crIsSplit` — otherwise the student has a single program and the stat
+    // keeps its plain "Score" label.
+    val crTrack: String?,
+    val crIsSplit: Boolean,
     val attendancePercent: Int?,
     // 1-based enrolled-semester ordinal ("6º").
     val semesterOrdinal: Int?,

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/MeScreen.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/MeScreen.kt
@@ -161,6 +161,7 @@ internal fun MeScreen(
                     IdentityCard(
                         identity = identity,
                         onEditProfile = { vm.onIntent(MeIntent.OpenEditProfile) },
+                        onCycleScoreProgram = { vm.onIntent(MeIntent.CycleScoreProgram) },
                     )
                     if (identity.semesterTotalWeeks > 0) {
                         Spacer(Modifier.height(14.dp))

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/MeViewModel.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/MeViewModel.kt
@@ -8,7 +8,7 @@ import dev.forcetower.melon.core.common.Outcome
 import dev.forcetower.melon.core.session.domain.SessionStore
 import dev.forcetower.melon.feature.campusevent.domain.usecase.ClearCampusEventUseCase
 import dev.forcetower.melon.feature.disciplines.domain.usecase.CalculateOverallScoreUseCase
-import dev.forcetower.melon.feature.disciplines.domain.usecase.OverallScoreSummary
+import dev.forcetower.melon.feature.disciplines.domain.model.ProgramScore
 import dev.forcetower.melon.feature.me.domain.model.AcademicDocument
 import dev.forcetower.melon.feature.me.domain.model.DocumentFetchError
 import dev.forcetower.melon.feature.me.domain.model.MeProfile
@@ -142,7 +142,7 @@ internal const val ProfileNameMaxLength = 24
 
 internal data class MeUiState(
     val profileRaw: MeProfile? = null,
-    val scoreRaw: OverallScoreSummary? = null,
+    val scoreRaw: ProgramScore? = null,
     val gates: FeatureGates = FeatureGates(),
     val documentSheet: DocumentSheetState? = null,
     val editProfile: ProfileEditState? = null,
@@ -179,7 +179,7 @@ internal class MeViewModel @Inject constructor(
             observeMeProfile().collect { value -> setState { copy(profileRaw = value) } }
         }
         viewModelScope.launch {
-            overallScore.summary().collect { value -> setState { copy(scoreRaw = value) } }
+            overallScore().collect { value -> setState { copy(scoreRaw = value.current) } }
         }
         viewModelScope.launch {
             featureFlags.gates.collect { value -> setState { copy(gates = value) } }
@@ -421,7 +421,7 @@ private val AcademicDocument.shortcutItemId: String
 private val ShortDateFormatter: DateTimeFormatter
     get() = DateTimeFormatter.ofPattern("d MMM", Locale.getDefault())
 
-private fun mapIdentity(raw: MeProfile, score: OverallScoreSummary?): ProfileIdentity {
+private fun mapIdentity(raw: MeProfile, score: ProgramScore?): ProfileIdentity {
     val canonical = raw.identity.userName.ifBlank { raw.identity.firstName }
     val first = raw.identity.firstName.ifBlank { canonical.substringBefore(' ') }
     val initial = first.firstOrNull()?.uppercaseChar()?.toString() ?: "?"

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/MeViewModel.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/MeViewModel.kt
@@ -8,6 +8,7 @@ import dev.forcetower.melon.core.common.Outcome
 import dev.forcetower.melon.core.session.domain.SessionStore
 import dev.forcetower.melon.feature.campusevent.domain.usecase.ClearCampusEventUseCase
 import dev.forcetower.melon.feature.disciplines.domain.usecase.CalculateOverallScoreUseCase
+import dev.forcetower.melon.feature.disciplines.domain.model.OverallScore
 import dev.forcetower.melon.feature.disciplines.domain.model.ProgramScore
 import dev.forcetower.melon.feature.me.domain.model.AcademicDocument
 import dev.forcetower.melon.feature.me.domain.model.DocumentFetchError
@@ -73,6 +74,9 @@ internal sealed interface MeIntent : UiIntent {
     // view sticks. iOS doesn't need this because `RootView` swaps the whole
     // `ConnectedView` destination, which destroys the VM.
     data object ResetLogout : MeIntent
+    // Advances the Score stat to the next program. Only reachable when the
+    // student has more than one.
+    data object CycleScoreProgram : MeIntent
 }
 
 internal sealed interface MeEffect : UiEffect
@@ -142,7 +146,10 @@ internal const val ProfileNameMaxLength = 24
 
 internal data class MeUiState(
     val profileRaw: MeProfile? = null,
-    val scoreRaw: ProgramScore? = null,
+    val scoreRaw: OverallScore = OverallScore.Empty,
+    // Which program the Score stat is showing. Null follows the program the
+    // student is currently in; tapping the stat pins an index and cycles.
+    val scoreProgramIndex: Int? = null,
     val gates: FeatureGates = FeatureGates(),
     val documentSheet: DocumentSheetState? = null,
     val editProfile: ProfileEditState? = null,
@@ -155,7 +162,11 @@ internal data class MeUiState(
     // Null until the profile flow emits — the screen hides the hero in that
     // window rather than substitute fake fixture content. `MeFixtures.identity`
     // is preview-only.
-    val identity: ProfileIdentity? = profileRaw?.let { mapIdentity(it, scoreRaw) }
+    val identity: ProfileIdentity? = profileRaw?.let { mapIdentity(it, shownProgram, scoreRaw.isSplit) }
+
+    // The pinned program if the student cycled to one, else the current one.
+    val shownProgram: ProgramScore?
+        get() = scoreProgramIndex?.let { scoreRaw.programs.getOrNull(it) } ?: scoreRaw.current
     val shortcuts: List<Shortcut> = MeFixtures.gridShortcuts(gates)
 }
 
@@ -179,7 +190,7 @@ internal class MeViewModel @Inject constructor(
             observeMeProfile().collect { value -> setState { copy(profileRaw = value) } }
         }
         viewModelScope.launch {
-            overallScore().collect { value -> setState { copy(scoreRaw = value.current) } }
+            overallScore().collect { value -> setState { copy(scoreRaw = value) } }
         }
         viewModelScope.launch {
             featureFlags.gates.collect { value -> setState { copy(gates = value) } }
@@ -211,7 +222,19 @@ internal class MeViewModel @Inject constructor(
             MeIntent.CancelLogout -> setState { copy(logoutStep = LogoutStep.Idle) }
             MeIntent.ConfirmLogout -> performLogout()
             MeIntent.ResetLogout -> setState {
-                copy(logoutStep = LogoutStep.Idle, profileRaw = null, scoreRaw = null, documentSheet = null)
+                copy(
+                    logoutStep = LogoutStep.Idle,
+                    profileRaw = null,
+                    scoreRaw = OverallScore.Empty,
+                    scoreProgramIndex = null,
+                    documentSheet = null,
+                )
+            }
+            MeIntent.CycleScoreProgram -> setState {
+                val programs = scoreRaw.programs
+                if (programs.size < 2) return@setState this
+                val shown = programs.indexOf(shownProgram).coerceAtLeast(0)
+                copy(scoreProgramIndex = (shown + 1) % programs.size)
             }
         }
     }
@@ -421,7 +444,7 @@ private val AcademicDocument.shortcutItemId: String
 private val ShortDateFormatter: DateTimeFormatter
     get() = DateTimeFormatter.ofPattern("d MMM", Locale.getDefault())
 
-private fun mapIdentity(raw: MeProfile, score: ProgramScore?): ProfileIdentity {
+private fun mapIdentity(raw: MeProfile, score: ProgramScore?, isSplit: Boolean): ProfileIdentity {
     val canonical = raw.identity.userName.ifBlank { raw.identity.firstName }
     val first = raw.identity.firstName.ifBlank { canonical.substringBefore(' ') }
     val initial = first.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
@@ -441,6 +464,8 @@ private fun mapIdentity(raw: MeProfile, score: ProgramScore?): ProfileIdentity {
         progressPct = semester?.progressPercent ?: 0,
         cr = score?.value,
         crDelta = score?.delta,
+        crTrack = score?.track,
+        crIsSplit = isSplit,
         attendancePercent = raw.attendancePercent,
         semesterOrdinal = raw.semesterOrdinal,
         semesterStart = formatShortDate(semester?.startDate),

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/components/IdentityCard.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/me/components/IdentityCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.School
 import androidx.compose.material3.Icon
@@ -65,6 +66,7 @@ internal fun IdentityCard(
     modifier: Modifier = Modifier,
     revealDelayMs: Int = 120,
     onEditProfile: (() -> Unit)? = null,
+    onCycleScoreProgram: (() -> Unit)? = null,
 ) {
     val fixed = MaterialTheme.melon.fixed
     val shape = RoundedCornerShape(28.dp)
@@ -111,7 +113,7 @@ internal fun IdentityCard(
                     .background(fixed.onHero.copy(alpha = 0.16f)),
             )
             Spacer(Modifier.height(16.dp))
-            StatsRow(identity)
+            StatsRow(identity, onCycleScoreProgram = onCycleScoreProgram)
         }
     }
 }
@@ -267,11 +269,21 @@ private fun Avatar(initial: String, avatarUrl: String?, showEditBadge: Boolean) 
 }
 
 @Composable
-private fun StatsRow(identity: ProfileIdentity) {
+private fun StatsRow(identity: ProfileIdentity, onCycleScoreProgram: (() -> Unit)?) {
     Row(modifier = Modifier.height(IntrinsicSize.Min)) {
+        // With more than one program the stat drops the generic "Score" label
+        // for the program's own name — an unlabelled CR is exactly what made
+        // this number unreadable — and tapping walks to the next program.
+        val cycle = onCycleScoreProgram?.takeIf { identity.crIsSplit }
         Stat(
-            label = stringResource(R.string.me_stat_score),
+            label = if (identity.crIsSplit) {
+                identity.crTrack ?: stringResource(R.string.program_undergrad)
+            } else {
+                stringResource(R.string.me_stat_score)
+            },
             value = formatGrade(identity.cr),
+            trailingIcon = if (cycle != null) Icons.Filled.Autorenew else null,
+            onClick = cycle,
             modifier = Modifier.weight(1f),
         ) {
             ScoreDelta(delta = identity.crDelta)
@@ -318,10 +330,20 @@ private fun Stat(
     value: String,
     modifier: Modifier = Modifier,
     valueSuffix: String? = null,
+    trailingIcon: ImageVector? = null,
+    onClick: (() -> Unit)? = null,
     footer: @Composable () -> Unit,
 ) {
     val onHero = MaterialTheme.melon.fixed.onHero
-    Column(modifier = modifier) {
+    Column(
+        modifier = if (onClick == null) {
+            modifier
+        } else {
+            modifier
+                .clip(RoundedCornerShape(10.dp))
+                .clickable(onClick = onClick)
+        },
+    ) {
         Text(
             text = label.uppercase(LocalConfiguration.current.locales[0]),
             style = MaterialTheme.typography.labelSmall.copy(
@@ -349,6 +371,17 @@ private fun Stat(
                     style = MaterialTheme.typography.bodyMedium.copy(fontSize = 14.sp),
                     color = onHero.copy(alpha = 0.7f),
                     modifier = Modifier.padding(bottom = 1.dp),
+                )
+            }
+            if (trailingIcon != null) {
+                Spacer(Modifier.width(5.dp))
+                Icon(
+                    imageVector = trailingIcon,
+                    contentDescription = stringResource(R.string.me_stat_score_cycle),
+                    tint = onHero.copy(alpha = 0.6f),
+                    modifier = Modifier
+                        .padding(bottom = 3.dp)
+                        .size(13.dp),
                 )
             }
         }

--- a/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/onboarding/ready/ReadyViewModel.kt
+++ b/apps/android/app/src/main/kotlin/dev/forcetower/unes/ui/feature/onboarding/ready/ReadyViewModel.kt
@@ -87,37 +87,22 @@ class ReadyViewModel @Inject constructor(
 
     private suspend fun loadStats() {
         val disciplines = observeDisciplinesList().first()
-        val summary = calculateOverallScore.summary().first()
-        val score = summary.value ?: currentPartialMean(disciplines)
+        // The CR of the program the student is in — a mestrado's grades never
+        // belong in the graduação's number, and vice versa.
+        val program = calculateOverallScore().first().current
+        val score = program?.value ?: currentPartialMean(disciplines)
         setState {
             copy(
                 score = score,
                 attendancePercent = attendancePercent(disciplines),
             )
         }
-        // Sparkline second — each point re-runs the CR query with a cap, so
-        // the cards render before this finishes.
-        if (summary.value != null) {
-            val spark = scoreHistory(disciplines)
-            setState { copy(scoreSpark = spark) }
+        // Sparkline second — it walks the whole program, so the cards render
+        // before this finishes.
+        if (program != null) {
+            val spark = calculateOverallScore.checkpoints(program.track).first()
+            setState { copy(scoreSpark = spark.takeIf { it.size >= 2 }.orEmpty()) }
         }
-    }
-
-    // Cumulative CR after each semester, oldest first. `capSemesterId` clips
-    // to semesters strictly before the cap, so the point that includes
-    // semester i uses semester i+1 as the cap; the newest point is uncapped.
-    private suspend fun scoreHistory(state: DisciplinesListState): List<Double> {
-        val ordered = (state.past + listOfNotNull(state.current))
-            .distinctBy { it.semesterId }
-            .sortedBy { it.semesterCode }
-        if (ordered.size < 2) return emptyList()
-        val points = mutableListOf<Double>()
-        for (i in 1 until ordered.size) {
-            calculateOverallScore(capSemesterId = ordered[i].semesterId).first()
-                ?.let { points += it }
-        }
-        calculateOverallScore().first()?.let { points += it }
-        return if (points.size >= 2) points else emptyList()
     }
 
     // Freshman fallback — no semester has closed grades yet, so surface the

--- a/apps/android/app/src/main/res/values-en/strings.xml
+++ b/apps/android/app/src/main/res/values-en/strings.xml
@@ -407,14 +407,14 @@
     <string name="disciplines_status_pending">No grades</string>
     <!-- endregion -->
 
+    <!-- Name of the regular undergrad program. Every other program is
+         labelled by the code upstream stamps on its semesters (RUE, PGM). -->
+    <string name="program_undergrad">Undergraduate</string>
     <!-- region Disciplinas · Histórico -->
     <string name="disciplines_history_performance">Cumulative performance</string>
     <string name="disciplines_history_overall_mean">overall average</string>
     <string name="disciplines_history_courses_taken">taken</string>
     <string name="disciplines_history_approval_rate">approval</string>
-    <!-- Program picker: label of the regular undergrad calendar. Other programs
-         are labelled by the code upstream stamps on their semesters (RUE, PGM). -->
-    <string name="disciplines_history_program_undergrad">Undergraduate</string>
     <!-- "4 disc." — compact discipline count next to the semester code. -->
     <plurals name="disciplines_history_disc_count">
         <item quantity="one">%d course</item>
@@ -624,6 +624,7 @@
     <string name="me_identity_campus_fallback">UEFS</string>
     <string name="me_stat_score">Score</string>
     <string name="me_stat_score_caption">overall</string>
+    <string name="me_stat_score_cycle">Show the other program\'s coefficient</string>
     <string name="me_stat_attendance">Attendance</string>
     <string name="me_stat_attendance_caption">present</string>
     <string name="me_stat_semester">Semester</string>

--- a/apps/android/app/src/main/res/values-en/strings.xml
+++ b/apps/android/app/src/main/res/values-en/strings.xml
@@ -412,6 +412,9 @@
     <string name="disciplines_history_overall_mean">overall average</string>
     <string name="disciplines_history_courses_taken">taken</string>
     <string name="disciplines_history_approval_rate">approval</string>
+    <!-- Program picker: label of the regular undergrad calendar. Other programs
+         are labelled by the code upstream stamps on their semesters (RUE, PGM). -->
+    <string name="disciplines_history_program_undergrad">Undergraduate</string>
     <!-- "4 disc." — compact discipline count next to the semester code. -->
     <plurals name="disciplines_history_disc_count">
         <item quantity="one">%d course</item>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -436,6 +436,9 @@
     <string name="disciplines_history_overall_mean">média geral</string>
     <string name="disciplines_history_courses_taken">cursadas</string>
     <string name="disciplines_history_approval_rate">aprovação</string>
+    <!-- Program picker: label of the regular undergrad calendar. Other programs
+         are labelled by the code upstream stamps on their semesters (RUE, PGM). -->
+    <string name="disciplines_history_program_undergrad">Graduação</string>
     <!-- "4 disc." — compact discipline count next to the semester code. -->
     <plurals name="disciplines_history_disc_count">
         <item quantity="one">%d disc.</item>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -431,14 +431,14 @@
     <string name="disciplines_status_pending">Sem notas</string>
     <!-- endregion -->
 
+    <!-- Name of the regular undergrad program. Every other program is
+         labelled by the code upstream stamps on its semesters (RUE, PGM). -->
+    <string name="program_undergrad">Graduação</string>
     <!-- region Disciplinas · Histórico -->
     <string name="disciplines_history_performance">Desempenho acumulado</string>
     <string name="disciplines_history_overall_mean">média geral</string>
     <string name="disciplines_history_courses_taken">cursadas</string>
     <string name="disciplines_history_approval_rate">aprovação</string>
-    <!-- Program picker: label of the regular undergrad calendar. Other programs
-         are labelled by the code upstream stamps on their semesters (RUE, PGM). -->
-    <string name="disciplines_history_program_undergrad">Graduação</string>
     <!-- "4 disc." — compact discipline count next to the semester code. -->
     <plurals name="disciplines_history_disc_count">
         <item quantity="one">%d disc.</item>
@@ -656,6 +656,7 @@
     <string name="me_stat_score">Score</string>
     <!-- Caption under the Score value when there is no visible delta. -->
     <string name="me_stat_score_caption">geral</string>
+    <string name="me_stat_score_cycle">Ver o coeficiente do outro programa</string>
     <string name="me_stat_attendance">Frequência</string>
     <string name="me_stat_attendance_caption">presença</string>
     <string name="me_stat_semester">Semestre</string>

--- a/apps/ios/UNESKit/Sources/UNESKit/Data/DTO/SyncDTO.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Data/DTO/SyncDTO.swift
@@ -76,6 +76,8 @@ struct SemesterListDTO: Decodable {
         var dirtyAt: String? = nil
         /// Enrolled disciplines, for the "download this semester" cards.
         var disciplineCount: Int? = nil
+        /// Program calendar; nil is the regular undergrad one.
+        var track: String? = nil
     }
 }
 
@@ -91,6 +93,7 @@ extension SemesterListDTO.ItemDTO {
             description: description,
             startDate: startDate,
             endDate: endDate,
+            track: track,
             disciplineCount: disciplineCount,
             dirtyAt: dirtyAt
         )
@@ -120,6 +123,8 @@ struct SemesterPayloadDTO: Decodable {
         let description: String
         let startDate: String
         let endDate: String
+        /// Program calendar; nil is the regular undergrad one.
+        var track: String? = nil
     }
 
     struct DisciplineDTO: Decodable {
@@ -236,7 +241,8 @@ extension SemesterPayloadDTO {
                 code: semester.code,
                 description: semester.description,
                 startDate: semester.startDate,
-                endDate: semester.endDate
+                endDate: semester.endDate,
+                track: semester.track
             ),
             disciplines: disciplines.map {
                 DisciplineRecord(

--- a/apps/ios/UNESKit/Sources/UNESKit/Data/Database/AppDatabase.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Data/Database/AppDatabase.swift
@@ -265,6 +265,14 @@ private func migrator() -> DatabaseMigrator {
             t.add(column: "authorName", .text)
         }
     }
+    // The program a semester belongs to. Backfilled by the next refresh —
+    // existing rows read as the undergrad calendar until then, which is what
+    // they were being treated as anyway.
+    migrator.registerMigration("v10") { db in
+        try db.alter(table: "semesters") { t in
+            t.add(column: "track", .text)
+        }
+    }
     return migrator
 }
 

--- a/apps/ios/UNESKit/Sources/UNESKit/Data/Database/CoefficientHistory.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Data/Database/CoefficientHistory.swift
@@ -2,10 +2,15 @@ import Foundation
 
 // MARK: - Mirror records → cross-semester CoefficientSummary
 
-/// The coefficient (CR) across every mirrored semester: the mean of all
-/// disciplines taken, each weighted by its class-hours, walked
-/// chronologically so the sparkline plots the CR as it stood after each
-/// semester.
+/// The coefficient (CR) of one program: the mean of every discipline taken
+/// in it, weighted by class-hours, walked chronologically so the sparkline
+/// plots the CR as it stood after each of its semesters.
+///
+/// A program is a semester track — nil is the regular undergrad calendar,
+/// anything else a program that runs its own (a mestrado, an EAD course).
+/// The CR is never taken across programs: a student who finished a
+/// graduação and started a mestrado has two, and their mean describes
+/// neither degree (issue #55).
 struct CoefficientHistory {
     var semesters: [SemesterRecord]
     var disciplines: [DisciplineRecord]
@@ -13,10 +18,20 @@ struct CoefficientHistory {
     var classes: [ClassRecord]
     var studentClasses: [StudentClassRecord]
 
+    /// The CR to show where there is room for exactly one number: the newest
+    /// program that has closed anything. A program the student just started
+    /// has no CR of its own yet, so it falls through to the previous one
+    /// rather than leaving the surface blank.
+    ///
     /// Nil until some discipline has a closed result — callers keep the
     /// active snapshot's partial mean as the stand-in until then.
     func summary() -> CoefficientSummary? {
-        let spark = checkpoints().map(\.value)
+        tracksByRecency().lazy.compactMap { summary(track: $0) }.first
+    }
+
+    /// One program's CR, or nil when none of its disciplines has closed.
+    func summary(track: String?) -> CoefficientSummary? {
+        let spark = checkpoints(track: track).map(\.value)
         guard let value = spark.last else { return nil }
         return CoefficientSummary(
             value: value,
@@ -25,11 +40,24 @@ struct CoefficientHistory {
         )
     }
 
-    /// The CR as it stood after each semester that closed anything, in
-    /// chronological order — the sparkline with its semesters attached, so
-    /// the Retrospectiva can read the before/after around one semester.
-    func checkpoints() -> [CoefficientCheckpoint] {
-        let ordered = semesters.sorted { ($0.startDate, $0.code) < ($1.startDate, $1.code) }
+    /// The programs the student has semesters in, newest first.
+    private func tracksByRecency() -> [String?] {
+        var tracks: [String?] = []
+        for semester in semesters.sorted(by: { ($0.startDate, $0.code) > ($1.startDate, $1.code) })
+        where !tracks.contains(semester.track) {
+            tracks.append(semester.track)
+        }
+        return tracks
+    }
+
+    /// The CR as it stood after each semester of one program that closed
+    /// anything, in chronological order — the sparkline with its semesters
+    /// attached, so the Retrospectiva can read the before/after around one
+    /// semester.
+    func checkpoints(track: String?) -> [CoefficientCheckpoint] {
+        let ordered = semesters
+            .filter { $0.track == track }
+            .sorted { ($0.startDate, $0.code) < ($1.startDate, $1.code) }
         let takenBySemester = takenBySemester()
 
         var gradeHours = 0.0

--- a/apps/ios/UNESKit/Sources/UNESKit/Data/Database/CoefficientHistory.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Data/Database/CoefficientHistory.swift
@@ -29,6 +29,14 @@ struct CoefficientHistory {
         tracksByRecency().lazy.compactMap { summary(track: $0) }.first
     }
 
+    /// Every program the student has a CR in, newest first. Programs with
+    /// nothing closed yet are left out — they have no coefficient to show.
+    func programs() -> [ProgramCoefficient] {
+        tracksByRecency().compactMap { track in
+            summary(track: track).map { ProgramCoefficient(track: track, summary: $0) }
+        }
+    }
+
     /// One program's CR, or nil when none of its disciplines has closed.
     func summary(track: String?) -> CoefficientSummary? {
         let spark = checkpoints(track: track).map(\.value)

--- a/apps/ios/UNESKit/Sources/UNESKit/Data/Database/MirrorStore+Retrospective.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Data/Database/MirrorStore+Retrospective.swift
@@ -62,7 +62,11 @@ extension MirrorStore {
         guard !summaries.isEmpty else { return nil }
 
         let semesters = try SemesterRecord.order(Column("startDate").desc).fetchAll(db)
-        let checkpoints = try coefficientHistory(semesters: semesters, db: db).checkpoints()
+        // Scoped to the recapped semester's own program — the CR movement in
+        // this deck belongs to that degree, not to a blend of every program
+        // the student has been in.
+        let checkpoints = try coefficientHistory(semesters: semesters, db: db)
+            .checkpoints(track: semester.track)
 
         let totalHours = summaries.reduce(0) { $0 + $1.hours }
         let missedHours = summaries.reduce(0) { $0 + $1.missedHours }

--- a/apps/ios/UNESKit/Sources/UNESKit/Data/Database/MirrorStore.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Data/Database/MirrorStore.swift
@@ -124,9 +124,13 @@ struct MirrorStore: Sendable {
            let record = semesters.first(where: { $0.id == active.id }) {
             overview = try snapshot(for: record, db: db).meOverview(now: now)
         }
-        if let coefficient = try coefficientHistory(semesters: semesters, db: db).summary() {
+        let history = try coefficientHistory(semesters: semesters, db: db)
+        if let coefficient = history.summary() {
             overview.coefficient = coefficient
         }
+        // The hero lets the student walk through their programs, so it needs
+        // all of them and not just the one it opens on.
+        overview.coefficientPrograms = history.programs()
         return CachedMeOverview(overview: overview, syncedAt: syncedAt)
     }
 

--- a/apps/ios/UNESKit/Sources/UNESKit/Data/Database/Records.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Data/Database/Records.swift
@@ -11,6 +11,10 @@ struct SemesterRecord: Codable, Equatable, Sendable, FetchableRecord, Persistabl
     /// yyyy-MM-dd, compared lexicographically.
     var startDate: String
     var endDate: String
+    /// Program calendar this semester belongs to — nil is the regular
+    /// undergrad one. Upstream stamps it on the semester code (22.1RUE →
+    /// "RUE"); it is what separates one degree's CR from another's.
+    var track: String? = nil
     /// Enrolled disciplines as counted upstream — sizes the "download this
     /// semester" cards before the payload is mirrored. Only the semester
     /// list carries it.

--- a/apps/ios/UNESKit/Sources/UNESKit/Domain/Models/HomeOverview.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Domain/Models/HomeOverview.swift
@@ -58,6 +58,17 @@ struct CoefficientSummary: Equatable, Sendable {
     var delta: Double?
 }
 
+/// One program's coefficient. `track` is the semester-track that identifies
+/// the program — nil is the regular undergrad calendar, anything else a
+/// program that runs its own (a mestrado, an EAD course). Programs are never
+/// averaged together; see `CoefficientHistory`.
+struct ProgramCoefficient: Equatable, Sendable, Identifiable {
+    var track: String?
+    var summary: CoefficientSummary
+
+    var id: String { track ?? "" }
+}
+
 struct AttendanceSummary: Equatable, Sendable {
     /// Presence guaranteed so far: `(1 - missed / total hours) × 100`.
     var percent: Int

--- a/apps/ios/UNESKit/Sources/UNESKit/Domain/Models/MeOverview.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Domain/Models/MeOverview.swift
@@ -10,6 +10,10 @@ struct MeOverview: Equatable, Sendable {
     /// "Campus · Módulo" where the student's classes most often meet.
     var campus: String?
     var coefficient: CoefficientSummary?
+    /// Every program the student has a coefficient in, newest first. One
+    /// entry for nearly everyone; a second appears when they take up a
+    /// mestrado or another program on its own calendar.
+    var coefficientPrograms: [ProgramCoefficient] = []
     var attendancePercent: Int?
     var progress: SemesterProgress?
     var countdown: SemesterCountdown?

--- a/apps/ios/UNESKit/Sources/UNESKit/Features/Me/MeFeature.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Features/Me/MeFeature.swift
@@ -44,8 +44,30 @@ struct MeFeature {
         @Shared(.appStorage(FeatureFlags.retrospectiveEnabledKey)) var isRetrospectiveEnabled = false
         /// The semester whose Retrospectiva window the mirror says is open.
         var retrospectiveSemester: String?
+        /// Which program the hero's Score stat is showing. Nil follows the
+        /// one the student is currently in; tapping the stat pins an index
+        /// and walks from there.
+        var scoreProgramIndex: Int?
 
         var displayName: String? { profile?.displayName ?? userName }
+
+        /// Programs the student has a coefficient in, newest first.
+        var coefficientPrograms: [ProgramCoefficient] { overview?.coefficientPrograms ?? [] }
+
+        /// The pinned program, else whichever the overview opened on.
+        var shownProgram: ProgramCoefficient? {
+            guard let scoreProgramIndex, coefficientPrograms.indices.contains(scoreProgramIndex)
+            else { return coefficientPrograms.first }
+            return coefficientPrograms[scoreProgramIndex]
+        }
+
+        /// What to label the Score stat with. Nil unless the student has more
+        /// than one program — everyone else keeps the plain "Score" label and
+        /// an untappable stat.
+        var shownProgramLabel: String? {
+            guard coefficientPrograms.count > 1 else { return nil }
+            return shownProgram?.track ?? String.localized(.programUndergrad)
+        }
 
         /// The flag-gated tile set — the gated shortcuts appear only while
         /// their flag is on. Always applies the filter, independent of build
@@ -110,6 +132,8 @@ struct MeFeature {
         case profileLoaded(Profile)
         case shortcutTapped(MeShortcut)
         case editProfileTapped
+        /// Walks the hero's Score stat to the next program.
+        case scoreProgramTapped
         case editProfile(PresentationAction<ProfileEditFeature.Action>)
         case deeplinkOpened(Deeplink)
         case settingsRowTapped(MeSettingsRow)
@@ -224,6 +248,13 @@ struct MeFeature {
                 guard let profile = state.profile else { return .none }
                 analytics.selectContent(contentType: ContentTypes.setting, itemId: "edit_profile")
                 state.editProfile = ProfileEditFeature.State(profile: profile)
+                return .none
+
+            case .scoreProgramTapped:
+                let programs = state.coefficientPrograms
+                guard programs.count > 1 else { return .none }
+                let shown = state.shownProgram.flatMap { programs.firstIndex(of: $0) } ?? 0
+                state.scoreProgramIndex = (shown + 1) % programs.count
                 return .none
 
             case .editProfile(.presented(.delegate(.saved))):

--- a/apps/ios/UNESKit/Sources/UNESKit/Features/Me/MeIdentityHero.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Features/Me/MeIdentityHero.swift
@@ -9,9 +9,16 @@ struct MeIdentityHero: View {
     var campus: String?
     var imageUrl: String?
     var coefficient: CoefficientSummary?
+    /// Program the coefficient belongs to ("Graduação", "RUE"). Non-nil only
+    /// when the student has more than one, in which case it replaces the
+    /// generic "Score" label — an unlabelled CR is unreadable once two
+    /// degrees are in play.
+    var programLabel: String?
     var attendancePercent: Int?
     var progress: SemesterProgress?
     var onEditProfile: (() -> Void)?
+    /// Walks to the next program. Nil keeps the stat untappable.
+    var onCycleProgram: (() -> Void)?
 
     /// The mesh backdrop, matching the design's `#160E1F`.
     private static let backdrop = Color(hex: 0x160E1F)
@@ -154,18 +161,38 @@ struct MeIdentityHero: View {
 
     private var statsRow: some View {
         HStack(alignment: .top, spacing: 4) {
-            stat(label: .meStatScore, value: formatGrade(coefficient?.value), delta: delta)
-            stat(label: .meStatAttendance, value: attendancePercent.map { "\($0)" } ?? "—",
+            scoreStat
+            stat(label: String.localized(.meStatAttendance), value: attendancePercent.map { "\($0)" } ?? "—",
                  sub: attendancePercent != nil ? "%" : nil)
-            stat(label: .meStatSemester, value: progress.map { "\($0.week)" } ?? "—",
+            stat(label: String.localized(.meStatSemester), value: progress.map { "\($0.week)" } ?? "—",
                  sub: progress.map { String.localized(.meStatWeeksShort($0.totalWeeks)) })
         }
     }
 
+    @ViewBuilder
+    private var scoreStat: some View {
+        let content = stat(
+            label: programLabel ?? String.localized(.meStatScore),
+            value: formatGrade(coefficient?.value),
+            trailingIcon: onCycleProgram == nil ? nil : "arrow.trianglehead.2.clockwise",
+            delta: delta
+        )
+        if let onCycleProgram {
+            Button(action: onCycleProgram) {
+                content.contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityHint(Text(.meStatScoreCycle))
+        } else {
+            content
+        }
+    }
+
     private func stat(
-        label: LocalizedStringResource,
+        label: String,
         value: String,
         sub: String? = nil,
+        trailingIcon: String? = nil,
         delta: (text: String, rising: Bool)? = nil
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -185,6 +212,11 @@ struct MeIdentityHero: View {
                     Text(sub)
                         .font(.system(size: 11.5, weight: .medium))
                         .monospacedDigit()
+                        .foregroundStyle(.white.opacity(0.55))
+                }
+                if let trailingIcon {
+                    Image(systemName: trailingIcon)
+                        .font(.system(size: 10, weight: .semibold))
                         .foregroundStyle(.white.opacity(0.55))
                 }
             }
@@ -216,9 +248,11 @@ struct MeIdentityHero: View {
         course: "Engenharia de Computação",
         campus: "UEFS · Módulo 5",
         coefficient: MeOverview.preview.coefficient,
+        programLabel: "RUE",
         attendancePercent: 96,
         progress: MeOverview.preview.progress,
-        onEditProfile: {}
+        onEditProfile: {},
+        onCycleProgram: {}
     )
     .padding(16)
     .frame(maxHeight: .infinity)

--- a/apps/ios/UNESKit/Sources/UNESKit/Features/Me/MeView.swift
+++ b/apps/ios/UNESKit/Sources/UNESKit/Features/Me/MeView.swift
@@ -94,10 +94,14 @@ struct MeView: View {
                     course: store.profile?.course,
                     campus: store.overview?.campus,
                     imageUrl: store.profile?.imageUrl,
-                    coefficient: store.overview?.coefficient,
+                    coefficient: store.shownProgram?.summary ?? store.overview?.coefficient,
+                    programLabel: store.shownProgramLabel,
                     attendancePercent: store.overview?.attendancePercent,
                     progress: store.overview?.progress,
-                    onEditProfile: { store.send(.editProfileTapped) }
+                    onEditProfile: { store.send(.editProfileTapped) },
+                    onCycleProgram: store.shownProgramLabel == nil
+                        ? nil
+                        : { store.send(.scoreProgramTapped) }
                 )
                 .scaleIn(delay: 0.1, duration: 0.62)
                 .padding(.bottom, 20)

--- a/apps/ios/UNESKit/Sources/UNESKit/Resources/Localizable.xcstrings
+++ b/apps/ios/UNESKit/Sources/UNESKit/Resources/Localizable.xcstrings
@@ -16834,6 +16834,23 @@
         }
       }
     },
+    "me.stat.scoreCycle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show the other program’s coefficient"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver o coeficiente do outro programa"
+          }
+        }
+      }
+    },
     "me.stat.semester" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -16864,6 +16881,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "/ %lld sem"
+          }
+        }
+      }
+    },
+    "program.undergrad" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Undergraduate"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Graduação"
           }
         }
       }

--- a/apps/ios/UNESKit/Tests/UNESKitTests/CoefficientHistoryTests.swift
+++ b/apps/ios/UNESKit/Tests/UNESKitTests/CoefficientHistoryTests.swift
@@ -6,8 +6,21 @@ import Testing
 /// The cross-semester coefficient: hours-weighted mean of every discipline
 /// taken, one cumulative spark point per semester.
 struct CoefficientHistoryTests {
-    private func semester(_ id: String, code: String, start: String, end: String) -> SemesterRecord {
-        SemesterRecord(id: id, code: code, description: "Semestre \(code)", startDate: start, endDate: end)
+    private func semester(
+        _ id: String,
+        code: String,
+        start: String,
+        end: String,
+        track: String? = nil
+    ) -> SemesterRecord {
+        SemesterRecord(
+            id: id,
+            code: code,
+            description: "Semestre \(code)",
+            startDate: start,
+            endDate: end,
+            track: track
+        )
     }
 
     @Test
@@ -174,6 +187,67 @@ struct CoefficientHistoryTests {
         #expect(summary.value == 8.5)
         #expect(summary.spark == [8.5])
         #expect(summary.delta == nil)
+    }
+
+    /// Issue #55: a mestrado runs on its own semester calendar under the same
+    /// login. Its grades belong to its own CR, not to the graduação's.
+    @Test
+    func eachProgramKeepsItsOwnCoefficient() throws {
+        let history = mixedProgramHistory(mastersGrade: "10.0")
+
+        let undergrad = try #require(history.summary(track: nil))
+        #expect(undergrad.value == 7.0)
+        #expect(undergrad.spark == [8.0, 7.0])
+
+        let masters = try #require(history.summary(track: "RUE"))
+        #expect(masters.value == 10.0)
+        #expect(masters.spark == [10.0])
+
+        // The single-number surfaces speak for the newest program.
+        #expect(history.summary()?.value == 10.0)
+    }
+
+    /// A program in its first semester has no closed grades yet — the hero
+    /// falls back to the previous program instead of going blank.
+    @Test
+    func aProgramWithoutClosedGradesFallsBackToThePreviousOne() throws {
+        let history = mixedProgramHistory(mastersGrade: nil)
+
+        #expect(history.summary(track: "RUE") == nil)
+        #expect(history.summary()?.value == 7.0)
+    }
+
+    /// A finished graduação (two semesters) followed by a mestrado, which
+    /// runs on its own calendar. Blended, the mestrado's 10.0 would drag the
+    /// graduação's 7.0 up to 8.0.
+    private func mixedProgramHistory(mastersGrade: String?) -> CoefficientHistory {
+        CoefficientHistory(
+            semesters: [
+                semester("ug1", code: "20251", start: "2025-02-01", end: "2025-06-30"),
+                semester("ug2", code: "20252", start: "2025-08-01", end: "2025-12-15"),
+                semester("ms1", code: "26.1RUE", start: "2026-03-01", end: "2026-07-30", track: "RUE"),
+            ],
+            disciplines: [
+                DisciplineRecord(id: "d1", semesterId: "ug1", code: "ALGI", name: "Algoritmos I", hours: 60),
+                DisciplineRecord(id: "d2", semesterId: "ms1", code: "RUE1", name: "Seminários", hours: 60),
+                DisciplineRecord(id: "d3", semesterId: "ug2", code: "LPOO", name: "POO", hours: 60),
+            ],
+            disciplineOffers: [
+                DisciplineOfferRecord(id: "o1", semesterId: "ug1", disciplineId: "d1"),
+                DisciplineOfferRecord(id: "o2", semesterId: "ms1", disciplineId: "d2"),
+                DisciplineOfferRecord(id: "o3", semesterId: "ug2", disciplineId: "d3"),
+            ],
+            classes: [
+                ClassRecord(id: "c1", semesterId: "ug1", offerId: "o1", hours: 60),
+                ClassRecord(id: "c2", semesterId: "ms1", offerId: "o2", hours: 60),
+                ClassRecord(id: "c3", semesterId: "ug2", offerId: "o3", hours: 60),
+            ],
+            studentClasses: [
+                StudentClassRecord(id: "sc1", semesterId: "ug1", classId: "c1", finalGrade: "8.0"),
+                StudentClassRecord(id: "sc2", semesterId: "ms1", classId: "c2", finalGrade: mastersGrade),
+                StudentClassRecord(id: "sc3", semesterId: "ug2", classId: "c3", finalGrade: "6.0"),
+            ]
+        )
     }
 
     @Test

--- a/apps/ios/UNESKit/Tests/UNESKitTests/MeFeatureTests.swift
+++ b/apps/ios/UNESKit/Tests/UNESKitTests/MeFeatureTests.swift
@@ -51,6 +51,50 @@ struct MeFeatureTests {
         }
     }
 
+    /// Issue #55: a student in a mestrado on top of their graduação has two
+    /// coefficients, and the hero walks between them instead of averaging.
+    @Test
+    func tappingTheScoreWalksThroughThePrograms() async {
+        var overview = MeOverview.preview
+        overview.coefficientPrograms = [
+            ProgramCoefficient(track: "RUE", summary: CoefficientSummary(value: 9.1, spark: [9.1], delta: nil)),
+            ProgramCoefficient(track: nil, summary: CoefficientSummary(value: 7.0, spark: [8.0, 7.0], delta: -1.0)),
+        ]
+        let store = TestStore(initialState: MeFeature.State(overview: overview)) {
+            MeFeature()
+        }
+
+        #expect(store.state.shownProgram?.track == "RUE")
+        #expect(store.state.shownProgramLabel == "RUE")
+
+        await store.send(.scoreProgramTapped) {
+            $0.scoreProgramIndex = 1
+        }
+        #expect(store.state.shownProgram?.summary.value == 7.0)
+        #expect(store.state.shownProgramLabel == String.localized(.programUndergrad))
+
+        // Wraps back around to the program they are in.
+        await store.send(.scoreProgramTapped) {
+            $0.scoreProgramIndex = 0
+        }
+        #expect(store.state.shownProgram?.track == "RUE")
+    }
+
+    /// A single program keeps the plain "Score" label and an inert stat.
+    @Test
+    func oneProgramLeavesTheScoreStatAlone() async {
+        var overview = MeOverview.preview
+        overview.coefficientPrograms = [
+            ProgramCoefficient(track: nil, summary: CoefficientSummary(value: 7.0, spark: [7.0], delta: nil)),
+        ]
+        let store = TestStore(initialState: MeFeature.State(overview: overview)) {
+            MeFeature()
+        }
+
+        #expect(store.state.shownProgramLabel == nil)
+        await store.send(.scoreProgramTapped)
+    }
+
     @Test
     func calendarShortcutPushesTheCalendar() async {
         let store = TestStore(initialState: MeFeature.State()) {

--- a/packages/shared-kmp/features/disciplines/build.gradle.kts
+++ b/packages/shared-kmp/features/disciplines/build.gradle.kts
@@ -17,5 +17,8 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.datetime)
         }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
     }
 }

--- a/packages/shared-kmp/features/disciplines/src/commonMain/kotlin/dev/forcetower/melon/feature/disciplines/domain/model/DisciplinesListModels.kt
+++ b/packages/shared-kmp/features/disciplines/src/commonMain/kotlin/dev/forcetower/melon/feature/disciplines/domain/model/DisciplinesListModels.kt
@@ -13,6 +13,10 @@ data class DisciplinesListState(
 data class SemesterDisciplines(
     val semesterId: String,
     val semesterCode: String,
+    // Program this semester belongs to; null is the undergrad calendar. See
+    // `ProgramScore`. The Histórico filters by it so a mestrado's semesters
+    // don't sit interleaved with the graduação's.
+    val track: String?,
     val disciplines: List<DisciplineListItem>,
 )
 
@@ -89,4 +93,5 @@ enum class DisciplineStatusKind {
 data class PendingSemester(
     val semesterId: String,
     val semesterCode: String,
+    val track: String?,
 )

--- a/packages/shared-kmp/features/disciplines/src/commonMain/kotlin/dev/forcetower/melon/feature/disciplines/domain/model/OverallScore.kt
+++ b/packages/shared-kmp/features/disciplines/src/commonMain/kotlin/dev/forcetower/melon/feature/disciplines/domain/model/OverallScore.kt
@@ -1,0 +1,39 @@
+package dev.forcetower.melon.feature.disciplines.domain.model
+
+// The CR of one program the student has taken disciplines in. A program is
+// identified by the semester track: `null` is the regular undergrad calendar
+// (2024.1, 2024.2, …), anything else is a program that runs its own calendar
+// — pós-graduação, EAD, and the year-long health-course cycles all show up
+// as tracked semesters (22.1RUE, 19.1PGM, 2023M).
+data class ProgramScore(
+    val track: String?,
+    val value: Double,
+    // `value` minus the CR as it stood before this program's most recent
+    // semester with closed grades. Null until two of its semesters closed.
+    val delta: Double?,
+    val semesterCount: Int,
+    val disciplineCount: Int,
+)
+
+// Every program CR the student has, most recently active first, plus which
+// one they are currently in. Programs without a single closed grade have no
+// entry — a freshly started mestrado shows up in `currentTrack` before it
+// shows up in `programs`.
+data class OverallScore(
+    val programs: List<ProgramScore>,
+    val currentTrack: String?,
+) {
+    // The program to show when the UI has room for exactly one number.
+    val current: ProgramScore?
+        get() = programs.firstOrNull { it.track == currentTrack } ?: programs.firstOrNull()
+
+    // False for the overwhelming majority of students, who only ever take
+    // undergrad disciplines. Screens keep their single-number layout until
+    // this flips.
+    val isSplit: Boolean
+        get() = programs.size > 1
+
+    companion object {
+        val Empty = OverallScore(programs = emptyList(), currentTrack = null)
+    }
+}

--- a/packages/shared-kmp/features/disciplines/src/commonMain/kotlin/dev/forcetower/melon/feature/disciplines/domain/usecase/CalculateOverallScoreUseCase.kt
+++ b/packages/shared-kmp/features/disciplines/src/commonMain/kotlin/dev/forcetower/melon/feature/disciplines/domain/usecase/CalculateOverallScoreUseCase.kt
@@ -4,6 +4,8 @@ import dev.forcetower.melon.core.database.dao.AcademicDao
 import dev.forcetower.melon.core.database.dao.SemesterDao
 import dev.forcetower.melon.core.database.entity.SemesterEntity
 import dev.forcetower.melon.core.database.query.EnrolledDisciplineRow
+import dev.forcetower.melon.feature.disciplines.domain.model.OverallScore
+import dev.forcetower.melon.feature.disciplines.domain.model.ProgramScore
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -12,90 +14,129 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 // Lifetime CR — weighted mean of every completed discipline's final grade
 // using its hour count as the weight. A discipline counts when its final
 // grade is set, regardless of approval. Multi-group enrollments collapse to
-// one contribution via `offerId`. The optional `capSemesterId` clips the
-// pool to semesters that started strictly before the cap, letting callers
-// ask "what was the CR up to semester X?".
+// one contribution via `offerId`.
+//
+// The mean is computed per program, never across them: a student who finished
+// a graduação and moved on to a mestrado has two CRs, and blending them
+// produces a number that belongs to neither. Programs are keyed by the
+// semester track — see `ProgramScore`.
 @Inject
 class CalculateOverallScoreUseCase internal constructor(
     private val semesterDao: SemesterDao,
     private val academicDao: AcademicDao,
 ) {
-    operator fun invoke(capSemesterId: String? = null): Flow<Double?> = combine(
+    operator fun invoke(): Flow<OverallScore> = combine(
         semesterDao.observeAll(),
         academicDao.observeAllEnrolledDisciplines(),
     ) { semesters, enrollments ->
-        computeOverallScore(semesters, enrollments, capSemesterId)
+        computeOverallScore(semesters, enrollments)
     }.distinctUntilChanged()
 
-    // Lifetime CR paired with its latest movement: `delta` = CR now − CR as
-    // it stood before the most recent semester with closed grades. Same
-    // semantics as the iOS sparkline delta (CoefficientHistory.swift); delta
-    // stays null until two semesters have closed grades.
-    fun summary(): Flow<OverallScoreSummary> = combine(
+    // One program's CR after each of its semesters that closed anything,
+    // oldest first — the sparkline series. Callers decide what to do with a
+    // series too short to draw.
+    fun checkpoints(track: String?): Flow<List<Double>> = combine(
         semesterDao.observeAll(),
         academicDao.observeAllEnrolledDisciplines(),
     ) { semesters, enrollments ->
-        computeOverallScoreSummary(semesters, enrollments)
+        computeCheckpoints(semesters, enrollments, track)
     }.distinctUntilChanged()
-}
-
-data class OverallScoreSummary(
-    val value: Double?,
-    val delta: Double?,
-)
-
-internal fun computeOverallScoreSummary(
-    semesters: List<SemesterEntity>,
-    enrollments: List<EnrolledDisciplineRow>,
-): OverallScoreSummary {
-    val value = computeOverallScore(semesters, enrollments, capSemesterId = null)
-    val lastClosed = semesters
-        .filter { semester ->
-            enrollments.any {
-                it.semesterId == semester.id &&
-                    it.disciplineHours > 0 &&
-                    it.finalGrade?.replace(",", ".")?.toDoubleOrNull() != null
-            }
-        }
-        .maxByOrNull { it.startDate }
-    val before = lastClosed?.let { computeOverallScore(semesters, enrollments, capSemesterId = it.id) }
-    return OverallScoreSummary(
-        value = value,
-        delta = if (value != null && before != null) value - before else null,
-    )
 }
 
 internal fun computeOverallScore(
     semesters: List<SemesterEntity>,
     enrollments: List<EnrolledDisciplineRow>,
-    capSemesterId: String?,
-): Double? {
-    val allowed: Set<String> = if (capSemesterId == null) {
-        semesters.mapTo(mutableSetOf()) { it.id }
-    } else {
-        val cap = semesters.firstOrNull { it.id == capSemesterId } ?: return null
-        semesters.asSequence()
-            .filter { it.startDate < cap.startDate }
-            .mapTo(mutableSetOf()) { it.id }
-    }
+): OverallScore {
+    val semesterById = semesters.associateBy { it.id }
+    val programs = closedContributions(semesterById, enrollments)
+        .groupBy { it.semester.track }
+        .entries
+        .sortedByDescending { (_, rows) -> rows.maxOf { it.semester.startDate } }
+        .mapNotNull { (track, rows) -> programScore(track, rows) }
 
-    val contributions = enrollments
-        .asSequence()
-        .filter { it.semesterId in allowed }
-        .mapNotNull { row ->
-            val grade = row.finalGrade?.replace(",", ".")?.toDoubleOrNull() ?: return@mapNotNull null
-            row to grade
-        }
-        .distinctBy { (row, _) -> row.offerId }
-        .toList()
+    return OverallScore(programs = programs, currentTrack = currentTrack(semesterById, enrollments))
+}
+
+internal fun computeCheckpoints(
+    semesters: List<SemesterEntity>,
+    enrollments: List<EnrolledDisciplineRow>,
+    track: String?,
+): List<Double> {
+    val semesterById = semesters.associateBy { it.id }
+    val bySemester = closedContributions(semesterById, enrollments)
+        .filter { it.semester.track == track }
+        .groupBy { it.semester }
 
     var weightedSum = 0.0
     var weightSum = 0.0
-    for ((row, grade) in contributions) {
-        val hours = row.disciplineHours
-        if (hours <= 0) continue
-        weightedSum += grade * hours
-        weightSum += hours
+    val points = mutableListOf<Double>()
+    for (semester in bySemester.keys.sortedBy { it.startDate }) {
+        for (row in bySemester.getValue(semester)) {
+            weightedSum += row.grade * row.hours
+            weightSum += row.hours
+        }
+        if (weightSum > 0.0) points += weightedSum / weightSum
+    }
+    return points
+}
+
+// Grade parsing runs before the per-offer dedup on purpose: a discipline that
+// runs as theory + practice carries its final grade on one of the two rows,
+// so deduping first would coin-flip the graded row away.
+private fun closedContributions(
+    semesterById: Map<String, SemesterEntity>,
+    enrollments: List<EnrolledDisciplineRow>,
+): List<Contribution> = enrollments
+    .asSequence()
+    .mapNotNull { row ->
+        val grade = row.finalGrade?.replace(",", ".")?.toDoubleOrNull() ?: return@mapNotNull null
+        row to grade
+    }
+    .distinctBy { (row, _) -> row.offerId }
+    .mapNotNull { (row, grade) ->
+        val semester = semesterById[row.semesterId] ?: return@mapNotNull null
+        if (row.disciplineHours <= 0) return@mapNotNull null
+        Contribution(semester = semester, grade = grade, hours = row.disciplineHours)
+    }
+    .toList()
+
+// The program the student is in right now — the track of the newest semester
+// they hold enrollments in, closed grades or not. Read off enrollments rather
+// than the semester list, which also carries semesters never downloaded.
+private fun currentTrack(
+    semesterById: Map<String, SemesterEntity>,
+    enrollments: List<EnrolledDisciplineRow>,
+): String? = enrollments
+    .asSequence()
+    .mapNotNull { semesterById[it.semesterId] }
+    .maxByOrNull { it.startDate }
+    ?.track
+
+private fun programScore(track: String?, rows: List<Contribution>): ProgramScore? {
+    val value = weightedMean(rows) ?: return null
+    val lastClosedStart = rows.maxOf { it.semester.startDate }
+    val before = weightedMean(rows.filter { it.semester.startDate < lastClosedStart })
+    return ProgramScore(
+        track = track,
+        value = value,
+        delta = before?.let { value - it },
+        semesterCount = rows.distinctBy { it.semester.id }.size,
+        disciplineCount = rows.size,
+    )
+}
+
+private fun weightedMean(rows: List<Contribution>): Double? {
+    var weightedSum = 0.0
+    var weightSum = 0.0
+    for (row in rows) {
+        weightedSum += row.grade * row.hours
+        weightSum += row.hours
     }
     return if (weightSum > 0.0) weightedSum / weightSum else null
 }
+
+private data class Contribution(
+    val semester: SemesterEntity,
+    val grade: Double,
+    val hours: Int,
+)

--- a/packages/shared-kmp/features/disciplines/src/commonMain/kotlin/dev/forcetower/melon/feature/disciplines/domain/usecase/ObserveDisciplinesListUseCase.kt
+++ b/packages/shared-kmp/features/disciplines/src/commonMain/kotlin/dev/forcetower/melon/feature/disciplines/domain/usecase/ObserveDisciplinesListUseCase.kt
@@ -74,7 +74,7 @@ private fun buildState(
         .asSequence()
         .filter { it.id !in downloadedSemesterIds }
         .sortedByDescending { it.endDate }
-        .map { PendingSemester(semesterId = it.id, semesterCode = it.code) }
+        .map { PendingSemester(semesterId = it.id, semesterCode = it.code, track = it.track) }
         .toList()
 
     return DisciplinesListState(current = current, past = past, pending = pending)
@@ -84,6 +84,7 @@ private fun SemesterEntity.toGroup(items: List<DisciplineListItem>): SemesterDis
     SemesterDisciplines(
         semesterId = id,
         semesterCode = code,
+        track = track,
         disciplines = items.sortedBy { it.code },
     )
 

--- a/packages/shared-kmp/features/disciplines/src/commonTest/kotlin/dev/forcetower/melon/feature/disciplines/CalculateOverallScoreTest.kt
+++ b/packages/shared-kmp/features/disciplines/src/commonTest/kotlin/dev/forcetower/melon/feature/disciplines/CalculateOverallScoreTest.kt
@@ -1,0 +1,157 @@
+package dev.forcetower.melon.feature.disciplines
+
+import dev.forcetower.melon.core.database.entity.SemesterEntity
+import dev.forcetower.melon.core.database.query.EnrolledDisciplineRow
+import dev.forcetower.melon.feature.disciplines.domain.usecase.computeOverallScore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+// A student who moves from a graduação into a mestrado keeps taking classes
+// under the same login, and the mestrado runs on its own semester calendar
+// (a track). Averaging both into one CR produces a number that describes
+// neither degree — see issue #55.
+class CalculateOverallScoreTest {
+
+    private val undergrad1 = semester("ug1", code = "20241", track = null, start = "2024-03-01")
+    private val undergrad2 = semester("ug2", code = "20242", track = null, start = "2024-08-01")
+    private val masters1 = semester("ms1", code = "25.1RUE", track = "RUE", start = "2025-03-01")
+
+    @Test
+    fun undergrad_only_student_has_a_single_program() {
+        val score = computeOverallScore(
+            semesters = listOf(undergrad1, undergrad2),
+            enrollments = listOf(
+                enrollment("o1", undergrad1, grade = "8.0", hours = 60),
+                enrollment("o2", undergrad2, grade = "6.0", hours = 60),
+            ),
+        )
+
+        assertEquals(1, score.programs.size)
+        assertTrue(!score.isSplit)
+        assertEquals(7.0, score.current?.value)
+        assertNull(score.current?.track)
+    }
+
+    @Test
+    fun masters_disciplines_do_not_move_the_undergrad_cr() {
+        val score = computeOverallScore(
+            semesters = listOf(undergrad1, undergrad2, masters1),
+            enrollments = listOf(
+                enrollment("o1", undergrad1, grade = "8.0", hours = 60),
+                enrollment("o2", undergrad2, grade = "6.0", hours = 60),
+                enrollment("o3", masters1, grade = "10.0", hours = 60),
+            ),
+        )
+
+        assertTrue(score.isSplit)
+        assertEquals(listOf("RUE", null), score.programs.map { it.track })
+        assertEquals(7.0, score.programs.first { it.track == null }.value)
+        assertEquals(10.0, score.programs.first { it.track == "RUE" }.value)
+    }
+
+    @Test
+    fun the_current_program_is_the_one_of_the_newest_enrollment() {
+        val score = computeOverallScore(
+            semesters = listOf(undergrad1, masters1),
+            enrollments = listOf(
+                enrollment("o1", undergrad1, grade = "8.0", hours = 60),
+                enrollment("o2", masters1, grade = "10.0", hours = 60),
+            ),
+        )
+
+        assertEquals("RUE", score.currentTrack)
+        assertEquals(10.0, score.current?.value)
+    }
+
+    // A mestrado in its first semester has enrollments but no closed grades,
+    // so it has no CR yet. The screens must still fall back to a real number
+    // instead of rendering nothing.
+    @Test
+    fun a_program_without_closed_grades_falls_back_to_the_newest_scored_one() {
+        val score = computeOverallScore(
+            semesters = listOf(undergrad1, masters1),
+            enrollments = listOf(
+                enrollment("o1", undergrad1, grade = "8.0", hours = 60),
+                enrollment("o2", masters1, grade = null, hours = 60),
+            ),
+        )
+
+        assertEquals("RUE", score.currentTrack)
+        assertEquals(1, score.programs.size)
+        assertEquals(8.0, score.current?.value)
+        assertNull(score.current?.track)
+    }
+
+    // The delta is the program's own movement: the undergrad CR must not
+    // jump because a mestrado semester closed in between.
+    @Test
+    fun delta_compares_against_the_previous_semester_of_the_same_program() {
+        val score = computeOverallScore(
+            semesters = listOf(undergrad1, masters1, undergrad2),
+            enrollments = listOf(
+                enrollment("o1", undergrad1, grade = "6.0", hours = 60),
+                enrollment("o2", masters1, grade = "10.0", hours = 60),
+                enrollment("o3", undergrad2, grade = "8.0", hours = 60),
+            ),
+        )
+
+        val undergrad = score.programs.first { it.track == null }
+        assertEquals(7.0, undergrad.value)
+        assertEquals(1.0, undergrad.delta)
+        assertNull(score.programs.first { it.track == "RUE" }.delta)
+    }
+
+    // Theory + practice groups arrive as two rows for one offer, and the
+    // final grade lands on only one of them.
+    @Test
+    fun multi_group_disciplines_count_once() {
+        val score = computeOverallScore(
+            semesters = listOf(undergrad1),
+            enrollments = listOf(
+                enrollment("o1", undergrad1, grade = null, hours = 60, classId = "c1"),
+                enrollment("o1", undergrad1, grade = "9.0", hours = 60, classId = "c2"),
+                enrollment("o2", undergrad1, grade = "7.0", hours = 60),
+            ),
+        )
+
+        assertEquals(8.0, score.current?.value)
+        assertEquals(2, score.current?.disciplineCount)
+    }
+
+    private fun semester(id: String, code: String, track: String?, start: String) = SemesterEntity(
+        id = id,
+        platformId = 0,
+        code = code,
+        description = code,
+        startDate = start,
+        endDate = start,
+        track = track,
+    )
+
+    private fun enrollment(
+        offerId: String,
+        semester: SemesterEntity,
+        grade: String?,
+        hours: Int,
+        classId: String = offerId,
+    ) = EnrolledDisciplineRow(
+        studentClassId = "sc-$classId",
+        classId = classId,
+        classType = "Teórica",
+        groupName = "T01",
+        offerId = offerId,
+        semesterId = semester.id,
+        disciplineHours = hours,
+        disciplineId = "d-$offerId",
+        disciplineCode = "EXA$offerId",
+        disciplineName = "Disciplina $offerId",
+        department = null,
+        finalGrade = grade,
+        approved = grade != null,
+        wentToFinals = false,
+        missedClasses = null,
+        teacherName = null,
+    )
+}

--- a/packages/shared-kmp/features/overview/src/commonMain/kotlin/dev/forcetower/melon/feature/overview/domain/usecase/ObserveGradeTileUseCase.kt
+++ b/packages/shared-kmp/features/overview/src/commonMain/kotlin/dev/forcetower/melon/feature/overview/domain/usecase/ObserveGradeTileUseCase.kt
@@ -21,6 +21,10 @@ import kotlinx.datetime.toLocalDateTime
 // active one. The math mirrors CalculateOverallScoreUseCase; the helper is
 // duplicated here on purpose (cross-feature `internal` doesn't carry, and
 // the codebase already prefers small local copies over a shared module).
+//
+// Everything is scoped to the active semester's program (its track), so a
+// student in a mestrado is not shown it averaged with the graduação they
+// already finished.
 @Inject
 class ObserveGradeTileUseCase internal constructor(
     private val semesterDao: SemesterDao,
@@ -42,11 +46,13 @@ private fun buildTile(
     enrollments: List<EnrolledDisciplineRow>,
     todayIso: String,
 ): OverviewGradeTile? {
-    val overall = overallScore(semesters, enrollments, capSemesterId = null) ?: return null
     val active = pickActiveSemester(semesters, todayIso)
-    val before = active?.let { overallScore(semesters, enrollments, capSemesterId = it.id) }
+    val track = currentTrack(semesters, enrollments, active)
+    val program = semesters.filter { it.track == track }
+    val overall = overallScore(program, enrollments, capSemesterId = null) ?: return null
+    val before = active?.let { overallScore(program, enrollments, capSemesterId = it.id) }
     val previousCode = active?.let { a ->
-        semesters
+        program
             .asSequence()
             .filter { it.id != a.id && it.startDate < a.startDate }
             .maxByOrNull { it.startDate }
@@ -57,6 +63,21 @@ private fun buildTile(
         crDelta = before?.let { overall - it },
         comparisonSemesterCode = previousCode?.takeIf { before != null },
     )
+}
+
+// The program the tile speaks for: the active semester's track, or — with no
+// active semester — the track of the newest semester holding enrollments.
+private fun currentTrack(
+    semesters: List<SemesterEntity>,
+    enrollments: List<EnrolledDisciplineRow>,
+    active: SemesterEntity?,
+): String? {
+    if (active != null) return active.track
+    val enrolledIds = enrollments.mapTo(mutableSetOf()) { it.semesterId }
+    return semesters
+        .filter { it.id in enrolledIds }
+        .maxByOrNull { it.startDate }
+        ?.track
 }
 
 private fun overallScore(


### PR DESCRIPTION
Fixes the CR blending reported in #55 (2019): a student who finishes a graduação and starts a mestrado keeps studying under the same login, so both degrees' disciplines fell into one lifetime CR. The number that comes out describes neither degree — it can sit a full point above or below the real one, in either direction, depending on how the second program is going.

## How programs are told apart

By the semester **track**: the suffix upstream stamps on a semester code (`22.1RUE`, `19.1PGM`, `2023M`), absent on the regular undergrad calendar. Postgrad, EAD and the year-long health cycles all run their own calendars, so this separates them cleanly — and it is the only per-discipline program signal that exists, since nothing upstream ties a turma to a course.

The API already sends `track` on both semester endpoints and KMP already stored it in `SemesterEntity`; no call site read it. iOS dropped it at decode, so this adds the column (`SemesterRecord`, migration `v10`) and carries it through both semester DTOs.

## What changed

**Shared (KMP)**
- `CalculateOverallScoreUseCase` returns an `OverallScore`: one `ProgramScore` per program, ordered by recency, plus the track the student is currently in. `current` gives the surfaces that have room for one number the current program, falling back to the newest program with closed grades so a freshly started mestrado doesn't blank the hero.
- `checkpoints(track:)` replaces the old `capSemesterId` sparkline, which re-ran the whole CR query once per semester. One pass now.
- The delta follows the same rule: a mestrado semester closing between two graduação semesters no longer moves the graduação's delta.
- `ObserveGradeTileUseCase` (Overview) scopes to the active semester's program.
- `SemesterDisciplines` / `PendingSemester` carry the track.

**Android**
- Histórico gets a chip row when there is more than one program; the semester list, "cursadas" and "aprovação" all scope to the pick.
- Me and the onboarding "tudo pronto" card read the current program.
- Students with a single program — nearly all of them — see exactly what they saw before: the picker only renders for a choice of more than one.

**iOS**
- `CoefficientHistory` walks one program at a time. `summary()` keeps its shape, so Home and the Watch complication needed no change; the Retrospectiva passes the recapped semester's own track.

**Eu tab (both platforms)**
- The hero's Score stat takes the program's own name — `Graduação`, `RUE` — in place of the generic label, and tapping it walks to the next program. Value, delta and the iOS sparkline all follow the pick.
- A student with a single program sees no change at all: the label stays "Score" and the stat is not tappable, so nobody gains a dead tap target.

## Tests

- New `CalculateOverallScoreTest` (KMP): programs stay separate, the current program is the newest enrollment's, a program with no closed grades falls back, per-program delta, multi-group dedup.
- New cases in `CoefficientHistoryTests` (iOS): per-program CR and the fallback.
- New cases in `MeFeatureTests` (iOS): the hero walks and wraps through the programs, and a single-program student's stat stays inert.
- `./gradlew testDebugUnitTest jvmTest lintDebug` and the full `UNESKit` suite (377 tests) pass.

## Not covered

- **Transfers within graduação.** Two undergrad courses share the same calendar, so their semesters are indistinguishable in the data — no track, no course on the offer. That case still needs the manual hide.
- **Program names.** Upstream gives us no name for a program, only the code it stamps on semesters, so the chips read `Graduação` / `RUE` / `PGM`. A code→name mapping would be a follow-up.
- The other half of #55 (documents not downloading for an aluno especial with graduação + mestrado) is a separate path and is untouched.
